### PR TITLE
Fix HMM notebook - `MultinomialHMM` was renamed to `CategoricalHMM`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,15 @@
-name: lpp-test
+name: lpp-tutorials
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9
+  - python=3.11
   - lipyphilic
   - ipywidgets
   - jupyter_contrib_nbextensions
   - widgetsnbextension
   - joblib
   - scikit-learn
-  - hmmlearn
+  - hmmlearn>=3.0
   - pytables
   - tabulate

--- a/notebooks/HiddenMarkovModel.ipynb
+++ b/notebooks/HiddenMarkovModel.ipynb
@@ -669,7 +669,7 @@
     "    n_lipids, n_frames = species_thickness.shape\n",
     "    lengths = np.full(n_lipids, fill_value=n_frames)\n",
     "    \n",
-    "    model = hmmlearn.hmm.MultinomialHMM(\n",
+    "    model = hmmlearn.hmm.CategoricalHMM(\n",
     "        n_components=n_hidden_states,\n",
     "        init_params='',\n",
     "        verbose=True,\n",


### PR DESCRIPTION
Fixes #1 

Changes made:
  - Use `hmmlearn.hmm.CategoricalHMM` rather than `hmmlearn.hmm.MultinomialHMM` - it was renamed in a recent release of HMMLearn
  - Update `environment.yml` to require `hmmlearn` >= 3.0
  - Update `environment.yml` to use Python 3.11